### PR TITLE
Add correct build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,9 @@ Source: lokkit-doorman
 Section: python
 Priority: optional
 Maintainer: Andreas Schmid, <ikeark@gmail.com>
-Build-Depends: virtualenv, debhelper (>= 7.4.3), dh-python, dh-systemd
+Build-Depends: debhelper (>= 7.4.3), dh-python, dh-systemd,
+ virtualenv,
+ python-all, python-setuptools
 Standards-Version: 3.9.1
 
 Package: lokkit-doorman

--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -1,0 +1,2 @@
+ethjsonrpc python-ethjsonrpc
+sha3 python-sha3

--- a/debian/rules
+++ b/debian/rules
@@ -6,3 +6,7 @@ export PYBUILD_NAME=doorman
 
 %:
 	dh $@ --with python2 --buildsystem=pybuild
+
+
+override_dh_auto_test:
+	@echo We dunno need no tests...


### PR DESCRIPTION
Ohne die Build-Dependencies `python-all` und `python-setuptools` kannst du gar nicht builden. 
Bzw. pybuild beschwert sich mit: 

```
E: Please add apropriate interpreter package to Build-Depends, see pybuild(1) for details at /usr/share/perl5/Debian/Debhelper/Buildsystem/pybuild.pm line 199.
```

Die unit tests habe ich ausgeschaltet, weil er da etwas mit ethjasonrpc machen will - habe ich nicht genauer angeschaut.

Ich glaube `virtualenv` kannst du dir in den build deps sparen.

Mit `pybuild 2.20170125 ` buildet es bei mir unter Ubuntu und enthaelt folgenden Package content:

```
drwxr-xr-x root/root         0 2017-06-16 00:02 ./
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/lib/
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/lib/python2.7/
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/doorman/
-rw-r--r-- root/root       112 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/doorman/__init__.py
-rw-r--r-- root/root      9267 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/doorman/doorman.py
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/lokkit_doorman-0.2.0.egg-info/
-rw-r--r-- root/root      1826 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/lokkit_doorman-0.2.0.egg-info/PKG-INFO
-rw-r--r-- root/root        77 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/lokkit_doorman-0.2.0.egg-info/dependency_links.txt
-rw-r--r-- root/root         1 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/lokkit_doorman-0.2.0.egg-info/not-zip-safe
-rw-r--r-- root/root        23 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/lokkit_doorman-0.2.0.egg-info/requires.txt
-rw-r--r-- root/root         8 2017-06-16 00:02 ./usr/lib/python2.7/dist-packages/lokkit_doorman-0.2.0.egg-info/top_level.txt
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/share/
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/share/doc/
drwxr-xr-x root/root         0 2017-06-16 00:02 ./usr/share/doc/lokkit-doorman/
-rw-r--r-- root/root       149 2017-06-16 00:02 ./usr/share/doc/lokkit-doorman/changelog.gz
```